### PR TITLE
Fix form layout on contribute page, and in popover

### DIFF
--- a/kuma/contributions/jinja2/contributions/includes/contribution-form.html
+++ b/kuma/contributions/jinja2/contributions/includes/contribution-form.html
@@ -7,7 +7,7 @@
     {% endif %}
     <div class="column-container">
         <img src="{{ static('img/hero-dino-blank.png') }}" class="backdrop-image" alt="" role="presentation" />
-        <div class="column-half">
+        <div class="column-half contribute-lead-in">
             <div class="container">
                 <h2 class="highlight highlight-spanned">
                     <span class="highlight-span">{{ _('Give Back to MDN')}}</span>

--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -369,29 +369,37 @@
         }
     }
 
+    var mediaQueryList = null;
+
+    /**
+     * Increases or decreases the height of the `popoverBanner`
+     * based on a `mediaQueryList` match
+     */
+    function handleViewportChange(evt) {
+        if (evt.matches) {
+            popoverBanner.removeClass('expanded');
+            popoverBanner.addClass('expanded-extend');
+        } else {
+            popoverBanner.removeClass('expanded-extend');
+            popoverBanner.addClass('expanded');
+        }
+    }
+
     /**
      * Expands the popover to show the full contents.
      */
     function expandCta() {
         var secondaryHeader = popoverBanner[0].querySelector('h4');
         var smallDesktop = '(max-width: 1092px)';
-        var mediaQueryList = window.matchMedia(smallDesktop);
+
+        mediaQueryList = window.matchMedia(smallDesktop);
         var initialExpandedClass = mediaQueryList.matches ? 'expanded-extend' : 'expanded';
 
         popoverBanner.addClass(initialExpandedClass + ' is-expanding');
         popoverBanner.removeClass('is-collapsed');
 
-        /* listen for matchMedia changes and extend, or
-           or contract, the popover height as appropriate */
-        mediaQueryList.addListener(function(evt) {
-            if (evt.matches) {
-                popoverBanner.removeClass('expanded');
-                popoverBanner.addClass('expanded-extend');
-            } else {
-                popoverBanner.removeClass('expanded-extend');
-                popoverBanner.addClass('expanded');
-            }
-        });
+        // listens for, and responds to, matchMedia events
+        mediaQueryList.addListener(handleViewportChange);
 
         popoverBanner.on('transitionend', function() {
             popoverBanner.removeClass('is-expanding');
@@ -424,8 +432,11 @@
 
         // Add transitional class for opacity animation.
         popoverBanner.addClass('is-collapsing');
-        popoverBanner.removeClass('expanded');
+        popoverBanner.removeClass('expanded expanded-extend');
         popoverBanner.attr('aria-expanded', false);
+
+        // remove the mediaQuery listener when in collapsed state
+        mediaQueryList.removeListener(handleViewportChange);
 
         popoverBanner.on('transitionend', function() {
             popoverBanner.addClass('is-collapsed');

--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -374,9 +374,24 @@
      */
     function expandCta() {
         var secondaryHeader = popoverBanner[0].querySelector('h4');
-        // Add transitional class for opacity animation.
-        popoverBanner.addClass('expanded is-expanding');
+        var smallDesktop = '(max-width: 1092px)';
+        var mediaQueryList = window.matchMedia(smallDesktop);
+        var initialExpandedClass = mediaQueryList.matches ? 'expanded-extend' : 'expanded';
+
+        popoverBanner.addClass(initialExpandedClass + ' is-expanding');
         popoverBanner.removeClass('is-collapsed');
+
+        /* listen for matchMedia changes and extend, or
+           or contract, the popover height as appropriate */
+        mediaQueryList.addListener(function(evt) {
+            if (evt.matches) {
+                popoverBanner.removeClass('expanded');
+                popoverBanner.addClass('expanded-extend');
+            } else {
+                popoverBanner.removeClass('expanded-extend');
+                popoverBanner.addClass('expanded');
+            }
+        });
 
         popoverBanner.on('transitionend', function() {
             popoverBanner.removeClass('is-expanding');

--- a/kuma/static/styles/components/contribution/banner.scss
+++ b/kuma/static/styles/components/contribution/banner.scss
@@ -39,9 +39,20 @@
         transition: height .5s;
         z-index: 99;
 
+        .form-footer {
+            margin-top: 0;
+        }
+
         &.expanded {
             height: 480px;
+        }
 
+        &.expanded-extend {
+            height: 580px;
+        }
+
+        &.expanded,
+        &.expanded-extend {
             // Locks position of Pay button and payment options while the
             // popover animates up and down.
             .contribution-form {
@@ -131,7 +142,7 @@
         left: auto;
         position: absolute;
         right: 0;
-        z-index: 0;
+        z-index: -1;
     }
 
     .hide-collapsed {
@@ -175,6 +186,20 @@
 
         &:first-of-type {
             margin-bottom: 1em;
+        }
+    }
+}
+
+@media #{$mq-mobile-and-down} {
+    .contribution-banner {
+
+        .contribute-lead-in {
+            text-align: center;
+        }
+
+        .contribution-form {
+            margin: 0 auto;
+            width: 80%;
         }
     }
 }

--- a/kuma/static/styles/components/contribution/form.scss
+++ b/kuma/static/styles/components/contribution/form.scss
@@ -5,12 +5,12 @@
     position: relative;
 
     .form-footer {
+        margin-top: $grid-spacing;
         white-space: nowrap;
-    }
+        text-align: center;
 
-    @media #{$mq-mobile-and-down} {
-        .form-footer button {
-            display: none;
+        @media #{$mq-tablet-and-up} {
+            text-align: left;
         }
     }
 
@@ -28,10 +28,6 @@
         padding: 0;
         text-align: center;
         white-space: nowrap;
-
-        @media #{$mq-mobile-and-down} {
-            width: 100%;
-        }
 
         &:hover {
             background-color: darken($contribution-form-button-color, 5%);
@@ -63,8 +59,13 @@
     }
 
     p.legal-copy {
-        font-size: 14px;
         margin: 2em 0 0;
+        font-size: 14px;
+        text-align: center;
+
+        @media #{$mq-tablet-and-up} {
+            text-align: left;
+        }
 
         a {
             color: $contribution-form-button-color;
@@ -121,7 +122,7 @@
             vertical-align: middle;
             width: 49%;
 
-            @media #{$mq-tablet-and-down} {
+            @media #{$mq-small-desktop-and-down} {
                 display: block;
                 width: 100%;
             }
@@ -129,6 +130,12 @@
     }
 
     .form-radios-donation-choices {
+        text-align: center;
+
+        @media #{$mq-large-desktop-and-up} {
+            text-align: left;
+        }
+
         li {
             display: inline-block;
             margin-right: 11px;
@@ -168,12 +175,13 @@
     }
 
     .payment-details {
-        display: inline-block;
-        margin: 0 10px;
-        vertical-align: middle;
+        display: block;
+        margin-top: $grid-spacing;
 
-        @media #{$mq-mobile-and-down} {
-            display: none;
+        @media #{$mq-mobile-and-up} {
+            display: inline-block;
+            margin: 0 10px;
+            vertical-align: middle;
         }
     }
 
@@ -289,5 +297,22 @@
     &:before {
         content: '\f00d';
         font-family: FontAwesome;
+    }
+}
+
+/* specific style for pop-over */
+.contribution-banner.contribution-popover {
+    .form-input-amount,
+    .form-radios-donation-choices {
+        border-radius: $contribution-form-input-height;
+        display: inline-block;
+        margin: $contribution-form-input-spacing 0 0;
+        vertical-align: middle;
+        width: 49%;
+
+        @media #{$mq-tablet-and-down} {
+            display: block;
+            width: 100%;
+        }
     }
 }


### PR DESCRIPTION
As the form on the contribute page can potentially be viewed on tablet and mobile devices it needs to be responsive all the way down to mobile. Currently there was a few issues

## Issue 1

<img width="830" alt="screen shot 2018-09-21 at 19 53 37" src="https://user-images.githubusercontent.com/10350960/45900031-ce84d000-bdde-11e8-96fd-e97b9bb2e822.png">

## Issue 2

<img width="791" alt="screen shot 2018-09-21 at 19 53 47" src="https://user-images.githubusercontent.com/10350960/45900043-d80e3800-bdde-11e8-9867-e2b18c04cc93.png">

I have resolved these and it is now responsive down to mobile viewports. I have also fixed some responsive problems with the firm when in a popover. At smaller viewports the form elements would stack, and some of the copy wrapped to additional lines. This caused the button to be pushed out of view, and scrolling was not enabled.

At these viewports, the dino head also obscured the pay button, and prevented a user from clicking it. This is now also resolved.